### PR TITLE
Replace tags with text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.2.0
 
 - Add `replacements` options to optionally replace tags with text.
+- Changed `removeWhitespace` option to `preserveWhitespace`.
 
 # 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.0
+
+- Add `replacements` options to optionally replace tags with text.
+
 # 0.1.0
 
 - Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add `replacements` options to optionally replace tags with text.
 - Changed `removeWhitespace` option to `preserveWhitespace`.
+- Properly handle nested tag exclusion.
 
 # 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ For example, script and style. Reduces multiple spaces to a single space
 and trims whitespace from the start and end by default. Set `preserveWhitespace`
 to `true` to disable this behavior. Optionally, replace tags with text.
 
+Offers a much nicer out-of-the-box experience compared to [striptags](https://www.npmjs.com/package/striptags).
+See comparison [here](https://runkit.com/dubiousdavid/extract-text-html-vs-striptags).
+
 Single dependency on [htmlparser2](https://www.npmjs.com/package/htmlparser2)
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -9,21 +9,21 @@ Single dependency on [htmlparser2](https://www.npmjs.com/package/htmlparser2)
 
 ```typescript
 export interface Replacement {
-  /** Tag name to match (without brackets) */
-  matchTag: string
-  /** Text to replace the tag with */
-  text: string
-  /** Is the tag self-closing?  */
-  isSelfClosing?: boolean
+    /** Tag name to match (without brackets) */
+    matchTag: string
+    /** Text to replace the tag with */
+    text: string
+    /** Is the tag self-closing?  */
+    isSelfClosing?: boolean
 }
 
 export interface Options {
-  /** Exclude the content from the set of tags. For example, style and script. */
-  excludeContentFromTags?: string[]
-  /** Whitespace is trimmed by default. Set this to true to preserve whitespace. */
-  preserveWhitespace?: boolean
-  /** Replace a tag with some text. Flag self-closing tags with isSelfClosing: true. */
-  replacements?: Replacement[]
+    /** Exclude the content from the set of tags. For example, style and script. */
+    excludeContentFromTags?: string[]
+    /** Whitespace is trimmed by default. Set this to true to preserve whitespace. */
+    preserveWhitespace?: boolean
+    /** Replace a tag with some text. Flag self-closing tags with isSelfClosing: true. */
+    replacements?: Replacement[]
 }
 ```
 
@@ -55,4 +55,28 @@ const html = `
     `
 const extracted = extractText(html)
 // Some Title Some text
+```
+
+Replacements example usage
+
+```typescript
+const html = `<b>bold <span>text</span></b>
+<div>some text</div>
+<br />
+<br>
+<p>more text</p>`
+const extracted = extractText(html, {
+    preserveWhitespace: true,
+    replacements: [
+        { matchTag: 'br', text: '  ', isSelfClosing: true },
+        { matchTag: 'b', text: '__' },
+    ],
+})
+/*
+__bold text__
+some text
+  
+  
+more text
+*/
 ```

--- a/README.md
+++ b/README.md
@@ -61,22 +61,20 @@ Replacements example usage
 
 ```typescript
 const html = `<b>bold <span>text</span></b>
-<div>some text</div>
-<br />
-<br>
+<div>some text</div><br /><br>
 <p>more text</p>`
 const extracted = extractText(html, {
     preserveWhitespace: true,
     replacements: [
-        { matchTag: 'br', text: '  ', isSelfClosing: true },
+        { matchTag: 'br', text: '\n', isSelfClosing: true },
         { matchTag: 'b', text: '__' },
     ],
 })
 /*
 __bold text__
 some text
-  
-  
+
+
 more text
 */
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # extract-text-html
 
 Extract text from HTML. Excludes content from metadata tags by default.
-For example, `script` and `style`. Removes excess whitespace by default.
-Optionally, replace tags with text.
+For example, script and style. Reduces multiple spaces to a single space
+and trims whitespace from the start and end by default. Set `preserveWhitespace`
+to `true` to disable this behavior. Optionally, replace tags with text.
 
 Single dependency on [htmlparser2](https://www.npmjs.com/package/htmlparser2)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ export interface Replacement {
   /** Text to replace the tag with */
   text: string
   /** Is the tag self-closing?  */
-  selfClosing?: boolean
+  isSelfClosing?: boolean
 }
 
 export interface Options {

--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ export interface Options {
     /** Replace a tag with some text. Flag self-closing tags with isSelfClosing: true. */
     replacements?: Replacement[]
 }
+
+// Content from the following tags are excluded by default
+export const defaultExcludeContentFromTags = [
+  'head',
+  'base',
+  'link',
+  'meta',
+  'noscript',
+  'script',
+  'style',
+  'title',
+]
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ export interface Replacement {
 }
 
 export interface Options {
-    /** Exclude the content from the set of tags. For example, style and script. */
+    /** Exclude content from the set of tags. Defaults to all HTML metadata tags. */
     excludeContentFromTags?: string[]
     /** Whitespace is trimmed by default. Set this to true to preserve whitespace. */
     preserveWhitespace?: boolean
@@ -31,14 +31,14 @@ export interface Options {
 
 // Content from the following tags are excluded by default
 export const defaultExcludeContentFromTags = [
-  'head',
-  'base',
-  'link',
-  'meta',
-  'noscript',
-  'script',
-  'style',
-  'title',
+    'head',
+    'base',
+    'link',
+    'meta',
+    'noscript',
+    'script',
+    'style',
+    'title',
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ Replacements example usage
 
 ```typescript
 const html = `<b>bold <span>text</span></b>
-<div>some text</div><br /><br>
-<p>more text</p>`
+<div>some text</div><br /><br><p>more text</p>`
 const extracted = extractText(html, {
     preserveWhitespace: true,
     replacements: [
@@ -88,7 +87,6 @@ const extracted = extractText(html, {
 /*
 __bold text__
 some text
-
 
 more text
 */

--- a/README.md
+++ b/README.md
@@ -2,15 +2,27 @@
 
 Extract text from HTML. Excludes content from metadata tags by default.
 For example, `script` and `style`. Removes excess whitespace by default.
+Optionally, replace tags with text.
 
 Single dependency on [htmlparser2](https://www.npmjs.com/package/htmlparser2)
 
 ```typescript
-type Options = {
+export interface Replacement {
+  /** Tag name to match (without brackets) */
+  matchTag: string
+  /** Text to replace the tag with */
+  text: string
+  /** Is the tag self-closing?  */
+  selfClosing?: boolean
+}
+
+export interface Options {
   /** Exclude the content from the set of tags. For example, style and script. */
   excludeContentFromTags?: string[]
   /** Reduces multiple spaces to a single space and trims whitespace from the start and end. */
   trimWhitespace?: boolean
+  /** Replace a tag with some text. Flag self-closing tags with selfClosing: true. */
+  replacements?: Replacement[]
 }
 ```
 
@@ -32,6 +44,11 @@ const html = `
     <div style="font-weight: bold">Some text</div>
     <script crossorigin="anonymous" src="https://static-production.npmjs.com/minicssextractbug.536095f4b1a94d2b149c.js"></script>
     <script crossorigin="anonymous" src="https://static-production.npmjs.com/search/search.9fbe393f02970084bce5.js"></script>
+    <script>
+      const FOO = 'bar'
+    </script>
+    <br />
+    <br />
   </body>
 </html>
     `

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ export interface Replacement {
 export interface Options {
   /** Exclude the content from the set of tags. For example, style and script. */
   excludeContentFromTags?: string[]
-  /** Reduces multiple spaces to a single space and trims whitespace from the start and end. */
-  trimWhitespace?: boolean
-  /** Replace a tag with some text. Flag self-closing tags with selfClosing: true. */
+  /** Whitespace is trimmed by default. Set this to true to preserve whitespace. */
+  preserveWhitespace?: boolean
+  /** Replace a tag with some text. Flag self-closing tags with isSelfClosing: true. */
   replacements?: Replacement[]
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,14 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "htmlparser2": "^9.0.0"
+        "@types/debug": "^4.1.12",
+        "debug": "^4.3.4",
+        "htmlparser2": "^9.0.0",
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
         "@types/jest": "^29.5.4",
+        "@types/lodash": "^4.17.0",
         "@typescript-eslint/eslint-plugin": "^6.5.0",
         "eslint": "^8.48.0",
         "prettier": "^2.8.8",
@@ -1390,6 +1394,14 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -1439,6 +1451,17 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
+      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
+      "dev": true
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
       "version": "20.5.7",
@@ -2165,7 +2188,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -3860,6 +3882,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -3968,8 +3995,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -6141,6 +6167,14 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -6190,6 +6224,17 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
+      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
+      "dev": true
+    },
+    "@types/ms": {
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "@types/node": {
       "version": "20.5.7",
@@ -6688,7 +6733,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -7956,6 +8000,11 @@
         "p-locate": "^5.0.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -8046,8 +8095,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,10 @@
       "dependencies": {
         "@types/debug": "^4.1.12",
         "debug": "^4.3.4",
-        "htmlparser2": "^9.0.0",
-        "lodash": "^4.17.21"
+        "htmlparser2": "^9.0.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.4",
-        "@types/lodash": "^4.17.0",
         "@typescript-eslint/eslint-plugin": "^6.5.0",
         "eslint": "^8.48.0",
         "prettier": "^2.8.8",
@@ -1450,12 +1448,6 @@
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
-      "dev": true
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
-      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
       "dev": true
     },
     "node_modules/@types/ms": {
@@ -3882,11 +3874,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -6225,12 +6212,6 @@
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
-      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
-      "dev": true
-    },
     "@types/ms": {
       "version": "0.7.34",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
@@ -7999,11 +7980,6 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.memoize": {
       "version": "4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "extract-text-html",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "extract-text-html",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "@types/debug": "^4.1.12",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "html",
     "strip",
     "tags",
-    "metadata"
+    "metadata",
+    "replace"
   ],
   "author": "GovSpend",
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extract-text-html",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Extract text from HTML. Excludes content from metadata tags by default.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
     "text",
     "html",
     "strip",
+    "tag",
     "tags",
     "metadata",
-    "replace"
+    "replace",
+    "replacement"
   ],
   "author": "GovSpend",
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "license": "ISC",
   "devDependencies": {
     "@types/jest": "^29.5.4",
+    "@types/lodash": "^4.17.0",
     "@typescript-eslint/eslint-plugin": "^6.5.0",
     "eslint": "^8.48.0",
     "prettier": "^2.8.8",
@@ -37,6 +38,9 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "htmlparser2": "^9.0.0"
+    "@types/debug": "^4.1.12",
+    "debug": "^4.3.4",
+    "htmlparser2": "^9.0.0",
+    "lodash": "^4.17.21"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "license": "ISC",
   "devDependencies": {
     "@types/jest": "^29.5.4",
-    "@types/lodash": "^4.17.0",
     "@typescript-eslint/eslint-plugin": "^6.5.0",
     "eslint": "^8.48.0",
     "prettier": "^2.8.8",
@@ -40,7 +39,6 @@
   "dependencies": {
     "@types/debug": "^4.1.12",
     "debug": "^4.3.4",
-    "htmlparser2": "^9.0.0",
-    "lodash": "^4.17.21"
+    "htmlparser2": "^9.0.0"
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
 import { extractText } from '.'
 
 describe('extractText', () => {
-  it('should extract text from well-formed HTML', () => {
+  it.only('should extract text from well-formed HTML', () => {
     const html = `
 <!doctype html>
 <html lang="en">
@@ -51,7 +51,7 @@ describe('extractText', () => {
     const extracted = extractText(html, {
       trimWhitespace: false,
       replacements: [
-        { matchTag: 'br', text: '  ', selfClosing: true },
+        { matchTag: 'br', text: '  ', isSelfClosing: true },
         { matchTag: 'b', text: '__' },
       ],
     })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -46,6 +46,16 @@ describe('extractText', () => {
     const extracted = extractText(html)
     expect(extracted).toBe('Some Title Some text')
   })
+  it('should handle custom excludeContentFromTags', () => {
+    const html = `
+    <div>
+      <div>Exclude</div>me
+    </div>
+    <p>Include me</p>
+    `
+    const extracted = extractText(html, { excludeContentFromTags: ['div'] })
+    expect(extracted).toBe('Include me')
+  })
   it('should replace tags with text and not trim whitespace', () => {
     const html = `<b>bold <span>text</span></b>
 <div>some text</div>

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,6 +9,11 @@ describe('extractText', () => {
     <meta charset="utf-8">
     <link rel="stylesheet" href="https://static-production.npmjs.com/styles.74f9073cf68d3c5f4990.css" />
     <title data-react-helmet="true">extracttext - npm search</title>
+    <style>
+      p {
+        color: #26b72b;
+      }
+    </style>
   </head>
   <body>
     <h1>Some Title</h1>
@@ -33,6 +38,16 @@ describe('extractText', () => {
       <link rel="stylesheet" href="https://static-production.npmjs.com/styles.74f9073cf68d3c5f4990.css" />
       Should not include
     </head>
+    <noscript>
+      <!-- anchor linking to external file -->
+      <a href="https://www.mozilla.org/">External Link</a>
+    </noscript>
+    <style>
+      p {
+        color: #26b72b;
+      }
+    </style>
+    <meta http-equiv="refresh" content="3;url=https://www.mozilla.org" />
     <TITLE data-react-helmet="true">extracttext - npm search</TITLE>
     <!-- Some comment -->
     <h1>Some Title</h1>

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
 import { extractText } from '.'
 
 describe('extractText', () => {
-  it('should extract text from well-formed HTML', () => {
+  it.only('should extract text from well-formed HTML', () => {
     const html = `
 <!doctype html>
 <html lang="en">
@@ -15,6 +15,11 @@ describe('extractText', () => {
     <div style="font-weight: bold">Some text</div>
     <script crossorigin="anonymous" src="https://static-production.npmjs.com/minicssextractbug.536095f4b1a94d2b149c.js"></script>
     <script crossorigin="anonymous" src="https://static-production.npmjs.com/search/search.9fbe393f02970084bce5.js"></script>
+    <script>
+      const FOO = 'bar'
+    </script>
+    <br />
+    <br />
   </body>
 </html>
     `
@@ -25,13 +30,39 @@ describe('extractText', () => {
     const html = `
     <meta charset="utf-8">
     <link rel="stylesheet" href="https://static-production.npmjs.com/styles.74f9073cf68d3c5f4990.css" />
-    <title data-react-helmet="true">extracttext - npm search</title>
+    <TITLE data-react-helmet="true">extracttext - npm search</TITLE>
     <h1>Some Title</h1>
-    <div style="font-weight: bold">Some text</div>
+    <div style="font-weight: bold">Some   text</div>
     <script crossorigin="anonymous" src="https://static-production.npmjs.com/minicssextractbug.536095f4b1a94d2b149c.js"></script>
     <script crossorigin="anonymous" src="https://static-production.npmjs.com/search/search.9fbe393f02970084bce5.js"></script>
+    <script>
+      const FOO = 'bar'
+    </script>
     `
     const extracted = extractText(html)
     expect(extracted).toBe('Some Title Some text')
+  })
+  it('should replace tags with text and not trim whitespace', () => {
+    const html = `<div style="font-weight: bold">bold text</div>
+<div>not bold</div>
+<br />
+<br>
+<p>more text</p>`
+    const extracted = extractText(html, {
+      trimWhitespace: false,
+      replacements: [
+        { matchTag: 'br', text: '  ', selfClosing: true },
+        {
+          matchTag: 'div',
+          matchAttrs: { style: 'font-weight: bold' },
+          text: '__',
+        },
+      ],
+    })
+    expect(extracted).toBe(`__bold text__
+not bold
+  
+  
+more text`)
   })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
 import { extractText } from '.'
 
 describe('extractText', () => {
-  it.only('should extract text from well-formed HTML', () => {
+  it('should extract text from well-formed HTML', () => {
     const html = `
 <!doctype html>
 <html lang="en">
@@ -43,8 +43,8 @@ describe('extractText', () => {
     expect(extracted).toBe('Some Title Some text')
   })
   it('should replace tags with text and not trim whitespace', () => {
-    const html = `<div style="font-weight: bold">bold text</div>
-<div>not bold</div>
+    const html = `<b>bold <span>text</span></b>
+<div>some text</div>
 <br />
 <br>
 <p>more text</p>`
@@ -52,15 +52,11 @@ describe('extractText', () => {
       trimWhitespace: false,
       replacements: [
         { matchTag: 'br', text: '  ', selfClosing: true },
-        {
-          matchTag: 'div',
-          matchAttrs: { style: 'font-weight: bold' },
-          text: '__',
-        },
+        { matchTag: 'b', text: '__' },
       ],
     })
     expect(extracted).toBe(`__bold text__
-not bold
+some text
   
   
 more text`)

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -73,21 +73,19 @@ describe('extractText', () => {
   })
   it('should replace tags with text and not trim whitespace', () => {
     const html = `<b>bold <span>text</span></b>
-<div>some text</div>
-<br />
-<br>
+<div>some text</div><br /><br>
 <p>more text</p>`
     const extracted = extractText(html, {
       preserveWhitespace: true,
       replacements: [
-        { matchTag: 'br', text: '  ', isSelfClosing: true },
+        { matchTag: 'br', text: '\n', isSelfClosing: true },
         { matchTag: 'b', text: '__' },
       ],
     })
     expect(extracted).toBe(`__bold text__
 some text
-  
-  
+
+
 more text`)
   })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
 import { extractText } from '.'
 
 describe('extractText', () => {
-  it.only('should extract text from well-formed HTML', () => {
+  it('should extract text from well-formed HTML', () => {
     const html = `
 <!doctype html>
 <html lang="en">
@@ -28,9 +28,12 @@ describe('extractText', () => {
   })
   it('should extract text from mal-formed HTML', () => {
     const html = `
-    <meta charset="utf-8">
-    <link rel="stylesheet" href="https://static-production.npmjs.com/styles.74f9073cf68d3c5f4990.css" />
-    <TITLE data-react-helmet="true">extracttext - npm search</TITLE>
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://static-production.npmjs.com/styles.74f9073cf68d3c5f4990.css" />
+      <TITLE data-react-helmet="true">extracttext - npm search</TITLE>
+      Should not include
+    </head>
     <h1>Some Title</h1>
     <div style="font-weight: bold">Some   text</div>
     <script crossorigin="anonymous" src="https://static-production.npmjs.com/minicssextractbug.536095f4b1a94d2b149c.js"></script>

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -73,8 +73,7 @@ describe('extractText', () => {
   })
   it('should replace tags with text and not trim whitespace', () => {
     const html = `<b>bold <span>text</span></b>
-<div>some text</div><br /><br>
-<p>more text</p>`
+<div>some text</div><br /><br><p>more text</p>`
     const extracted = extractText(html, {
       preserveWhitespace: true,
       replacements: [
@@ -84,7 +83,6 @@ describe('extractText', () => {
     })
     expect(extracted).toBe(`__bold text__
 some text
-
 
 more text`)
   })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -34,6 +34,7 @@ describe('extractText', () => {
       Should not include
     </head>
     <TITLE data-react-helmet="true">extracttext - npm search</TITLE>
+    <!-- Some comment -->
     <h1>Some Title</h1>
     <div style="font-weight: bold">Some   text</div>
     <script crossorigin="anonymous" src="https://static-production.npmjs.com/minicssextractbug.536095f4b1a94d2b149c.js"></script>

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -31,9 +31,9 @@ describe('extractText', () => {
     <head>
       <meta charset="utf-8">
       <link rel="stylesheet" href="https://static-production.npmjs.com/styles.74f9073cf68d3c5f4990.css" />
-      <TITLE data-react-helmet="true">extracttext - npm search</TITLE>
       Should not include
     </head>
+    <TITLE data-react-helmet="true">extracttext - npm search</TITLE>
     <h1>Some Title</h1>
     <div style="font-weight: bold">Some   text</div>
     <script crossorigin="anonymous" src="https://static-production.npmjs.com/minicssextractbug.536095f4b1a94d2b149c.js"></script>

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -52,7 +52,7 @@ describe('extractText', () => {
 <br>
 <p>more text</p>`
     const extracted = extractText(html, {
-      trimWhitespace: false,
+      preserveWhitespace: true,
       replacements: [
         { matchTag: 'br', text: '  ', isSelfClosing: true },
         { matchTag: 'b', text: '__' },

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,8 +44,8 @@ const stack = () => {
     tagStack.pop()
     return tagStack.length
   }
-  const length = () => tagStack.length
-  return { add, remove, length }
+  const isEmpty = () => tagStack.length === 0
+  return { add, remove, isEmpty }
 }
 
 /**
@@ -81,7 +81,7 @@ export const extractText = (html: string, options: Options = {}) => {
       }
     },
     ontext(text) {
-      if (!excludeStack.length()) {
+      if (excludeStack.isEmpty()) {
         strippedText += text
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export interface Replacement {
 }
 
 export interface Options {
-  /** Exclude the content from the set of tags. For example, style and script. */
+  /** Exclude content from the set of tags. Defaults to all HTML metadata tags. */
   excludeContentFromTags?: string[]
   /** Whitespace is trimmed by default. Set this to true to preserve whitespace. */
   preserveWhitespace?: boolean
@@ -21,7 +21,7 @@ export interface Options {
   replacements?: Replacement[]
 }
 
-// Exclude content from metadata tags.
+// Exclude content from HTML metadata tags.
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#metadata_content
 export const defaultExcludeContentFromTags = [
   'head',

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export interface Replacement {
 export interface Options {
   /** Exclude the content from the set of tags. For example, style and script. */
   excludeContentFromTags?: string[]
-  /** Do not trim whitespace. */ 
+  /** Whitespace is trimmed by default. Set this to true to preserve whitespace. */ 
   preserveWhitespace?: boolean
   /** Replace a tag with some text. Flag self-closing tags with isSelfClosing: true. */
   replacements?: Replacement[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export interface Replacement {
   /** Text to replace the tag with */
   text: string
   /** Is the tag self-closing?  */
-  selfClosing?: boolean
+  isSelfClosing?: boolean
 }
 
 export interface Options {
@@ -58,6 +58,7 @@ export const extractText = (html: string, options: Options = {}) => {
     onopentagname(name) {
       debug('open tag name %s', name)
       if (shouldExclude(name)) {
+        debug('start excluding')
         excludeText = true
       }
       const replacement = findReplacement(name)
@@ -74,10 +75,11 @@ export const extractText = (html: string, options: Options = {}) => {
     onclosetag(name) {
       debug('close tag name %s', name)
       if (shouldExclude(name)) {
+        debug('stop excluding')
         excludeText = false
       }
       const replacement = findReplacement(name)
-      if (options.replacements && replacement && !replacement.selfClosing) {
+      if (options.replacements && replacement && !replacement.isSelfClosing) {
         debug('replace close tag %s with %s', name, replacement.text)
         strippedText += replacement.text
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ export const extractText = (html: string, options: Options = {}) => {
   const trimWhitespace = options.trimWhitespace ?? true
   const replacements = options.replacements ?? []
 
-  let excludeText = false
+  let excludeTextForTag = ''
   let strippedText = ''
 
   const shouldExclude = (name: string) => excludeTags.includes(name)
@@ -57,9 +57,9 @@ export const extractText = (html: string, options: Options = {}) => {
   const parser = new htmlparser2.Parser({
     onopentagname(name) {
       debug('open tag name %s', name)
-      if (shouldExclude(name)) {
+      if (shouldExclude(name) && excludeTextForTag === '') {
         debug('start excluding')
-        excludeText = true
+        excludeTextForTag = name
       }
       const replacement = findReplacement(name)
       if (options.replacements && replacement) {
@@ -68,15 +68,15 @@ export const extractText = (html: string, options: Options = {}) => {
       }
     },
     ontext(text) {
-      if (!excludeText) {
+      if (!excludeTextForTag) {
         strippedText += text
       }
     },
     onclosetag(name) {
       debug('close tag name %s', name)
-      if (shouldExclude(name)) {
+      if (shouldExclude(name) && excludeTextForTag === name) {
         debug('stop excluding')
-        excludeText = false
+        excludeTextForTag = ''
       }
       const replacement = findReplacement(name)
       if (options.replacements && replacement && !replacement.isSelfClosing) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export const defaultExcludeContentFromTags = [
 /**
  * Extract text from HTML. Excludes content from metadata tags by default.
  * For example, script and style. Removes excess whitespace by default.
+ * Optionally, replace tags with text.
  */
 export const extractText = (html: string, options: Options = {}) => {
   // Options

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ export const extractText = (html: string, options: Options = {}) => {
   const excludeStack: string[] = []
   let extractedText = ''
 
-  const shouldExcludeTag = (name: string) => excludeTags.includes(name)
+  const isExcludedTag = (name: string) => excludeTags.includes(name)
 
   const findReplacement = (name: string) =>
     replacements.find(({ matchTag }) => matchTag === name)
@@ -57,7 +57,7 @@ export const extractText = (html: string, options: Options = {}) => {
   const parser = new htmlparser2.Parser({
     onopentagname(name) {
       debug('open tag name %s', name)
-      if (shouldExcludeTag(name) && excludeStack.push(name) === 1) {
+      if (isExcludedTag(name) && excludeStack.push(name) === 1) {
         debug('start excluding')
       }
       if (options.replacements) {
@@ -75,7 +75,7 @@ export const extractText = (html: string, options: Options = {}) => {
     },
     onclosetag(name) {
       debug('close tag name %s', name)
-      if (shouldExcludeTag(name)) {
+      if (isExcludedTag(name)) {
         excludeStack.pop()
         if (excludeStack.length === 0) {
           debug('stop excluding')

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,27 @@
+import { isMatch } from 'lodash'
 import * as htmlparser2 from 'htmlparser2'
+import _debug from 'debug'
 
-type Options = {
+const debug = _debug('extract-text-html')
+
+export interface Replacement {
+  /** Tag name to match (without brackets) */
+  matchTag: string
+  /** Attributes to match */
+  matchAttrs?: Record<string, string>
+  /** Text to replace the tag with */
+  text: string
+  /** Is the tag self-closing?  */
+  selfClosing?: boolean
+}
+
+export interface Options {
   /** Exclude the content from the set of tags. For example, style and script. */
   excludeContentFromTags?: string[]
   /** Reduces multiple spaces to a single space and trims whitespace from the start and end. */
   trimWhitespace?: boolean
+  /** Replace a tag with some text. Flag self-closing tags with selfClosing: true. */
+  replacements?: Replacement[]
 }
 
 // Exclude content from metadata tags.
@@ -29,16 +46,34 @@ export const extractText = (html: string, options: Options = {}) => {
   const excludeTags =
     options.excludeContentFromTags ?? defaultExcludeContentFromTags
   const trimWhitespace = options.trimWhitespace ?? true
+  const replacements = options.replacements ?? []
 
   let excludeText = false
   let strippedText = ''
+  let replacement: Replacement | undefined
 
   const shouldExclude = (name: string) => excludeTags.includes(name)
 
+  const findReplacement = (name: string, attrs: Record<string, string> = {}) =>
+    replacements.find(({ matchTag, matchAttrs }) => {
+      if (matchTag === name) {
+        if (matchAttrs) {
+          return isMatch(attrs, matchAttrs)
+        }
+        return true
+      }
+    })
+
   const parser = new htmlparser2.Parser({
-    onopentagname(name) {
+    onopentag(name, attrs) {
+      debug('open tag name %s', name)
       if (shouldExclude(name)) {
         excludeText = true
+      }
+      replacement = findReplacement(name, attrs)
+      if (options.replacements && replacement) {
+        debug('replace open tag %s with attrs %o', name, attrs)
+        strippedText += replacement.text
       }
     },
     ontext(text) {
@@ -47,8 +82,13 @@ export const extractText = (html: string, options: Options = {}) => {
       }
     },
     onclosetag(name) {
+      debug('close tag name %s', name)
       if (shouldExclude(name)) {
         excludeText = false
+      }
+      if (options.replacements && replacement && !replacement.selfClosing) {
+        debug('replace close tag %s with %s', name, replacement.text)
+        strippedText += replacement.text
       }
     },
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,8 +51,8 @@ const stack = () => {
 /**
  * Extract text from HTML. Excludes content from metadata tags by default.
  * For example, script and style. Reduces multiple spaces to a single space
- * and trims whitespace from the start and end by default. Set preserveWhitespace
- * to true to disable this behavior. Optionally, replace tags with text.
+ * and trims whitespace from the start and end by default. Set `preserveWhitespace`
+ * to `true` to disable this behavior. Optionally, replace tags with text.
  */
 export const extractText = (html: string, options: Options = {}) => {
   // Options

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ export const extractText = (html: string, options: Options = {}) => {
   const replacements = options.replacements ?? []
 
   const excludeStack: string[] = []
-  let strippedText = ''
+  let extractedText = ''
 
   const shouldExclude = (name: string) => excludeTags.includes(name)
 
@@ -64,13 +64,13 @@ export const extractText = (html: string, options: Options = {}) => {
         const replacement = findReplacement(name)
         if (replacement) {
           debug('replace open tag %s with %s', name, replacement.text)
-          strippedText += replacement.text
+          extractedText += replacement.text
         }
       }
     },
     ontext(text) {
       if (!excludeStack.length) {
-        strippedText += text
+        extractedText += text
       }
     },
     onclosetag(name) {
@@ -85,7 +85,7 @@ export const extractText = (html: string, options: Options = {}) => {
         const replacement = findReplacement(name)
         if (replacement && !replacement.isSelfClosing) {
           debug('replace close tag %s with %s', name, replacement.text)
-          strippedText += replacement.text
+          extractedText += replacement.text
         }
       }
     },
@@ -94,7 +94,7 @@ export const extractText = (html: string, options: Options = {}) => {
   parser.end()
 
   return options.preserveWhitespace
-    ? strippedText
+    ? extractedText
     : // Remove excess whitespace
-      strippedText.replace(/\s+/g, ' ').trim()
+      extractedText.replace(/\s+/g, ' ').trim()
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ export const extractText = (html: string, options: Options = {}) => {
   const excludeStack: string[] = []
   let extractedText = ''
 
-  const shouldExclude = (name: string) => excludeTags.includes(name)
+  const shouldExcludeTag = (name: string) => excludeTags.includes(name)
 
   const findReplacement = (name: string) =>
     replacements.find(({ matchTag }) => matchTag === name)
@@ -57,7 +57,7 @@ export const extractText = (html: string, options: Options = {}) => {
   const parser = new htmlparser2.Parser({
     onopentagname(name) {
       debug('open tag name %s', name)
-      if (shouldExclude(name) && excludeStack.push(name) === 1) {
+      if (shouldExcludeTag(name) && excludeStack.push(name) === 1) {
         debug('start excluding')
       }
       if (options.replacements) {
@@ -75,7 +75,7 @@ export const extractText = (html: string, options: Options = {}) => {
     },
     onclosetag(name) {
       debug('close tag name %s', name)
-      if (shouldExclude(name)) {
+      if (shouldExcludeTag(name)) {
         excludeStack.pop()
         if (excludeStack.length === 0) {
           debug('stop excluding')

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export interface Options {
   excludeContentFromTags?: string[]
   /** Reduces multiple spaces to a single space and trims whitespace from the start and end. */
   trimWhitespace?: boolean
-  /** Replace a tag with some text. Flag self-closing tags with selfClosing: true. */
+  /** Replace a tag with some text. Flag self-closing tags with isSelfClosing: true. */
   replacements?: Replacement[]
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,10 +74,12 @@ export const extractText = (html: string, options: Options = {}) => {
       if (shouldExclude(name) && excludeStack.add(name) === 1) {
         debug('start excluding')
       }
-      const replacement = findReplacement(name)
-      if (options.replacements && replacement) {
-        debug('replace open tag %s with %s', name, replacement.text)
-        strippedText += replacement.text
+      if (options.replacements) {
+        const replacement = findReplacement(name)
+        if (replacement) {
+          debug('replace open tag %s with %s', name, replacement.text)
+          strippedText += replacement.text
+        }
       }
     },
     ontext(text) {
@@ -90,10 +92,12 @@ export const extractText = (html: string, options: Options = {}) => {
       if (shouldExclude(name) && excludeStack.remove() === 0) {
         debug('stop excluding')
       }
-      const replacement = findReplacement(name)
-      if (options.replacements && replacement && !replacement.isSelfClosing) {
-        debug('replace close tag %s with %s', name, replacement.text)
-        strippedText += replacement.text
+      if (options.replacements) {
+        const replacement = findReplacement(name)
+        if (replacement && !replacement.isSelfClosing) {
+          debug('replace close tag %s with %s', name, replacement.text)
+          strippedText += replacement.text
+        }
       }
     },
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,17 +34,17 @@ export const defaultExcludeContentFromTags = [
   'title',
 ]
 
-const stack = () => {
-  const tagStack: string[] = []
-  const add = (tagName: string) => {
-    tagStack.push(tagName)
-    return tagStack.length
+const newStack = <T>() => {
+  const stack: T[] = []
+  const add = (item: T) => {
+    stack.push(item)
+    return stack.length
   }
   const remove = () => {
-    tagStack.pop()
-    return tagStack.length
+    stack.pop()
+    return stack.length
   }
-  const isEmpty = () => tagStack.length === 0
+  const isEmpty = () => stack.length === 0
   return { add, remove, isEmpty }
 }
 
@@ -60,7 +60,7 @@ export const extractText = (html: string, options: Options = {}) => {
     options.excludeContentFromTags ?? defaultExcludeContentFromTags
   const replacements = options.replacements ?? []
 
-  const excludeStack = stack()
+  const excludeStack = newStack<string>()
   let strippedText = ''
 
   const shouldExclude = (name: string) => excludeTags.includes(name)

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,8 @@ export interface Replacement {
 export interface Options {
   /** Exclude the content from the set of tags. For example, style and script. */
   excludeContentFromTags?: string[]
-  /** Reduces multiple spaces to a single space and trims whitespace from the start and end. */
-  trimWhitespace?: boolean
+  /** Do not trim whitespace. */ 
+  preserveWhitespace?: boolean
   /** Replace a tag with some text. Flag self-closing tags with isSelfClosing: true. */
   replacements?: Replacement[]
 }
@@ -36,14 +36,14 @@ export const defaultExcludeContentFromTags = [
 
 /**
  * Extract text from HTML. Excludes content from metadata tags by default.
- * For example, script and style. Removes excess whitespace by default.
- * Optionally, replace tags with text.
+ * For example, script and style. Reduces multiple spaces to a single space
+ * and trims whitespace from the start and end by default. Set preserveWhitespace
+ * to true to disable this behavior. Optionally, replace tags with text.
  */
 export const extractText = (html: string, options: Options = {}) => {
   // Options
   const excludeTags =
     options.excludeContentFromTags ?? defaultExcludeContentFromTags
-  const trimWhitespace = options.trimWhitespace ?? true
   const replacements = options.replacements ?? []
 
   let excludeTextForTag = ''
@@ -88,8 +88,8 @@ export const extractText = (html: string, options: Options = {}) => {
   parser.write(html)
   parser.end()
 
-  // Remove excess whitespace if needed
-  return trimWhitespace
-    ? strippedText.replace(/\s+/g, ' ').trim()
-    : strippedText
+  return options.preserveWhitespace
+    ? strippedText
+    : // Remove excess whitespace
+      strippedText.replace(/\s+/g, ' ').trim()
 }


### PR DESCRIPTION
- Add `replacements` options to optionally replace tags with text.
- Changed `removeWhitespace` option to `preserveWhitespace`.
- Properly handle nested tag exclusion.