### PR TITLE
@types/debug should not be part of the build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
-        "@types/debug": "^4.1.12",
         "debug": "^4.3.4",
         "htmlparser2": "^9.0.0"
       },
       "devDependencies": {
+        "@types/debug": "^4.1.12",
         "@types/jest": "^29.5.4",
         "@typescript-eslint/eslint-plugin": "^6.5.0",
         "eslint": "^8.48.0",
@@ -1396,6 +1396,8 @@
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
       "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
       }
@@ -1453,7 +1455,8 @@
     "node_modules/@types/ms": {
       "version": "0.7.34",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
-      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "20.5.7",
@@ -6158,6 +6161,7 @@
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
       "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dev": true,
       "requires": {
         "@types/ms": "*"
       }
@@ -6215,7 +6219,8 @@
     "@types/ms": {
       "version": "0.7.34",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
-      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
+      "dev": true
     },
     "@types/node": {
       "version": "20.5.7",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "license": "ISC",
   "devDependencies": {
+    "@types/debug": "^4.1.12",
     "@types/jest": "^29.5.4",
     "@typescript-eslint/eslint-plugin": "^6.5.0",
     "eslint": "^8.48.0",
@@ -40,7 +41,6 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@types/debug": "^4.1.12",
     "debug": "^4.3.4",
     "htmlparser2": "^9.0.0"
   }


### PR DESCRIPTION
By convention @types/* packages should not be part of a build.
This will create unnecessary conflicts with other versions of this package.

Thanks for this package, btw 👍